### PR TITLE
replace error type assertion with errors.As() to support wrapped errors

### DIFF
--- a/mysql_error_numbers.go
+++ b/mysql_error_numbers.go
@@ -1,6 +1,7 @@
 package mysqlerrnum
 
 import (
+	"errors"
 	"regexp"
 	"strconv"
 
@@ -25,7 +26,8 @@ func FromError(err error) ErrorNumber {
 		return ErrUnknownMySQLError
 	}
 
-	if e, ok := err.(*mysql.MySQLError); ok {
+	var e *mysql.MySQLError
+	if errors.As(err, &e) {
 		return FromNumber(int(e.Number))
 	}
 

--- a/mysql_error_numbers_test.go
+++ b/mysql_error_numbers_test.go
@@ -2,6 +2,7 @@ package mysqlerrnum
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/go-sql-driver/mysql"
@@ -29,6 +30,16 @@ func TestFromError(t *testing.T) {
 			err: &mysql.MySQLError{
 				Number: 1216,
 			},
+			expects:            ErrNoReferencedRow,
+			expectsString:      "ER_NO_REFERENCED_ROW",
+			expectsDescription: "InnoDB reports this error when you try to add a row but there is no parent row, and a foreign key constraint fails. Add the parent row first.",
+		},
+		{
+			name: "Extract from wrapped error",
+			err: fmt.Errorf("wrapped error %w",
+				&mysql.MySQLError{
+					Number: 1216,
+				}),
 			expects:            ErrNoReferencedRow,
 			expectsString:      "ER_NO_REFERENCED_ROW",
 			expectsDescription: "InnoDB reports this error when you try to add a row but there is no parent row, and a foreign key constraint fails. Add the parent row first.",


### PR DESCRIPTION
Switching `FromError()` from a direct type assertion to `errors.As()` to support both `*mysql.MySQLError` errors and those that have been wrapped.

Fixes #3 